### PR TITLE
Feat/analyzer component registry

### DIFF
--- a/articles/vespa-lucene-linguistics-analyzers.md
+++ b/articles/vespa-lucene-linguistics-analyzers.md
@@ -1,0 +1,58 @@
+# Vespa Lucene Linguistics Analyzer Priority
+
+#### 2023-07-28
+
+## TL;DR
+
+The analysis priority is as follows:
+```text
+Linguistics configuration > Components > Language Defaults > StandardAnalyzer
+```
+
+## Context
+
+When it comes to Analyzers the Vespa Lucene Linguistics component is highly configurable.
+However, the configuration with XML is a bit verbose and your IDE can't help preventing mistakes.
+There is another way to specify Lucene analyzers: add Analyzer classes into the classpath and
+declare them as components in your `services.xml`.
+When Vespa container is being started up JDisc creates a [ComponentRegistry<Analyzer>](https://docs.vespa.ai/en/jdisc/injecting-components.html#depending-on-all-components-of-a-specific-type)
+and injects it into LuceneLinguistics.
+Exposing this option allows you to craft analyzers with the help of your favourite IDE.
+
+## Analyzer components
+
+The resource files, e.g. stopword dictionaries should be loaded as resources from the Java project and not from the application package.
+
+### When there is only a no argument constructor
+
+### When there are multiple constructors.
+
+## Default Analyzers
+
+`LuceneLinguistics` already depends on `lucene-analysis-common` package which includes many analyzers for different languages.
+Why not to use them?
+The `DefaultAnalyzers` class does just that.
+It stores a mapping from the `Language` to an `Analyzer` object.
+It should serve as a solid base for implementing lexical search functionality.
+
+## Priority of analyzers
+
+Since there are multiple ways to define an analyzer for a language there might be conflicts.
+LuceneLinguistics defines the following conflict resolution strategy:
+
+````text
+if Analyzer is already known
+- then return it
+else if there is a configured component
+- then setup, add to language map, and return it
+else if there is a configured analyzer component
+- then add it to language map, return it
+else if there is a default analyzer
+- then add to language map and return it
+else return the standard analyzer
+````
+
+## Conclusion
+
+`LuceneLinguistics` implementation turned out to be highly flexible.
+It supports multiple extension mechanisms which.

--- a/articles/vespa-lucene-linguistics.md
+++ b/articles/vespa-lucene-linguistics.md
@@ -73,9 +73,11 @@ Analyzer construction logic is encoded in the [`AnalyzerFactory`](https://github
 
 A tricky bit was to configure Vespa to load data from resource files.
 Luckily, there is a `Builder` constructor that accepts `Path` parameter.
+
 ```c++
- public static Builder builder(Path configDir)
- ```
+public static Builder builder(Path configDir)
+```
+
 And `Path` is the type exposed by the Vespa [configuration definition language](https://docs.vespa.ai/en/reference/config-files.html)!
 Once deployed `Path` in the configuration points to where the files are stored in the Vespa `services` nodes, e.g. `/opt/vespa/var/db/vespa/filedistribution/dd3c228bd80aaf34/lucene`.
 This allows to set relative paths in the Lucene config, e.g. stopwords dictionary files.
@@ -96,8 +98,9 @@ private List<Token> textToTokens(String text, Analyzer analyzer) {
     try {
         tokenStream.reset();
         while (tokenStream.incrementToken()) {
+            String originalString = text.substring(offsetAttribute.startOffset(), offsetAttribute.endOffset());
             String tokenString = charTermAttribute.toString();
-            tokens.add(new SimpleToken(tokenString, tokenString)
+            tokens.add(new SimpleToken(originalString, tokenString)
                     .setType(TokenType.ALPHABETIC)
                     .setOffset(offsetAttribute.startOffset())
                     .setScript(TokenScript.UNKNOWN));
@@ -110,8 +113,6 @@ private List<Token> textToTokens(String text, Analyzer analyzer) {
     return tokens;
 }
 ```
-
-I'm not entirely sure if I've got the conversion into `Token` right, but it at this stage it works.
 
 Tokenizer decides how to process the input string according to three parameters:
 ```c++

--- a/src/journal/vespa/linguistics/container.clj
+++ b/src/journal/vespa/linguistics/container.clj
@@ -8,7 +8,7 @@
 (defn package! [in-container]
   [(tc/execute-command!
      in-container
-     ["sh" "-c" (format "(cd %s && mvn clean -DskipTests package)" linguistics-dir)])
+     ["sh" "-c" (format "(cd %s && mvn clean -DskipTests install)" linguistics-dir)])
    (tc/execute-command!
      in-container
      ["sh" "-c" (format "(cd %s && mvn clean -DskipTests package)" vap-dir)])])

--- a/src/journal/vespa/linguistics/core.clj
+++ b/src/journal/vespa/linguistics/core.clj
@@ -2,9 +2,11 @@
   (:require [journal.utils.json :as json]
             [clj-test-containers.core :as tc]
             [clojure.string :as str]
-            [org.httpkit.client :as http]
             [journal.vespa.searcher.core :as searcher]
             [journal.vespa.linguistics.container :as container]))
+
+(def field "mytext")
+
 (defn feed-document! [in-container]
   (tc/execute-command!
     in-container
@@ -22,40 +24,48 @@
         ["sh" "-c" "ls /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/"])
       (:stdout)
       (str/trim)))
+
+(defn flush-to-disk! []
+  (tc/execute-command!
+    @container/vespa
+    ["sh" "-c" "/opt/vespa/bin/vespa-proton-cmd --local triggerFlush"]))
+
+(defn list-tokens []
+  (let [index-dir (list-index-files @container/vespa)]
+    (->> (tc/execute-command!
+           @container/vespa
+           ["sh" "-c"
+            (format
+              "/opt/vespa/bin/vespa-index-inspect dumpwords \\
+          --indexdir  /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/%s/ \\
+          --wordnum \\
+          --field %s"
+              index-dir field)])
+         (:stdout))))
+
+(defn show-postings []
+  (let [index-dir (list-index-files @container/vespa)]
+    (->> (tc/execute-command!
+           @container/vespa
+           ["sh" "-c"
+            (format
+              "/opt/vespa/bin/vespa-index-inspect showpostings \\
+          --indexdir  /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/%s/ \\
+          --field %s --transpose"
+              index-dir field)])
+         (:stdout))))
+
 (comment
-  (delete-document! @container/vespa)
-
   (do
+    (container/build-vap-and-deploy! @container/vespa)
+    (Thread/sleep 1000)
+    (delete-document! @container/vespa)
     (feed-document! @container/vespa)
-    ; this should be executed first
-    (tc/execute-command!
-      @container/vespa
-      ["sh" "-c" "/opt/vespa/bin/vespa-proton-cmd --local triggerFlush"])
-
-    ; List the tokens
-    (let [index-dir (list-index-files @container/vespa)]
-      (->> (tc/execute-command!
-             @container/vespa
-             ["sh" "-c"
-              (format
-                "/opt/vespa/bin/vespa-index-inspect dumpwords \\
-            --indexdir  /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/%s/ \\
-            --wordnum \\
-            --field mytext"
-                index-dir)])
-           (:stdout)))))
-;(str/split-lines)
-;(mapv (fn [kw] (str/split kw #"\t")))
-;(into {}),))))
-
+    (flush-to-disk!)
+    (println "TOKEN LIST:\n" (list-tokens))
+    (println "POSTINGS:\n" (show-postings))))
 
 (defn vap-container-port [] (get (:mapped-ports @container/vespa) 8080))
-
-(defn foo []
-  @(http/request
-     {:method  :get
-      :url     (format "http://localhost:%s" (vap-container-port))
-      :headers {"Content-Type" "application/json"}}))
 
 (comment
   (in-ns 'journal.vespa.linguistics.core)
@@ -68,33 +78,50 @@
 
   (tc/stop! @container/vespa)
 
+  (-> (searcher/http-call
+        {}
+        {}
+        {"query"          "havneenheter"
+         "grammar"        "any"
+         "model.language" "no"
+         "yql"            "select * from sources * where userInput(@query) timeout 100"
+         "traceLevel"     "2"}
+        (vap-container-port))
+      :body
+      (json/read-str))
 
   (-> (searcher/http-call
-        {"language" "en"}
         {}
-        {"query"          "ZERO"
+        {}
+        {"query"          "jedeno i dwa"
+         "grammar"        "any"
+         "model.language" "pl"
+         "yql"            "select * from sources * where userInput(@query) timeout 100"
+         "traceLevel"     "2"}
+        (vap-container-port))
+      :body
+      (json/read-str))
+
+  (-> (searcher/http-call
+        {}
+        {}
+        {"query"          "somethings"
          "grammar"        "any"
          "model.language" "en"
-         "yql"            "select * from sources * where default contains ({stem: false} \"zero\") timeout 100"
-         "traceLevel"     "1"}
+         "yql"            "select * from sources * where userInput(@query) timeout 100"
+         "traceLevel"     "2"}
+        (vap-container-port))
+      :body
+      (json/read-str))
+
+  (-> (searcher/http-call
+        {}
+        {}
+        {"query"          "somethings"
+         "grammar"        "any"
+         "model.language" "en"
+         "yql"            "select * from sources * where true timeout 100"
+         "traceLevel"     "2"}
         (vap-container-port))
       :body
       (json/read-str)))
-
-;; docker exec vespa bash -c '/opt/vespa/bin/vespa-proton-cmd --local triggerFlush && \
-;    /opt/vespa/bin/vespa-index-inspect dumpwords \
-;    --indexdir /opt/vespa/var/db/vespa/search/cluster.music/n0/documents/music/0.ready/index/index.fusion.3 \
-;    --field album'
-
-; TODO: linguistics reverses term multiple times during query
-;
-;vespa-index-inspect dumpwords \
-;    --indexdir /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/$(ls /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/) \
-;    --field mytext
-
-; Check the posting list
-; vespa-index-inspect showpostings --indexdir /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/$(ls /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/) --field mytext_index --transpose
-
-
-; Flush and see the tokens
-; /opt/vespa/bin/vespa-proton-cmd --local triggerFlush && vespa-index-inspect dumpwords     --indexdir /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/$(ls /opt/vespa/var/db/vespa/search/cluster.content/n0/documents/lucene/0.ready/index/)     --field mytext_inde

--- a/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/AnalyzerFactory.java
+++ b/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/AnalyzerFactory.java
@@ -70,7 +70,7 @@ public class AnalyzerFactory {
             return setAndReturn(analyzerKey, analyzerComponents.getComponent(analyzerKey));
         }
         if (null != defaultAnalyzers.get(language)) {
-            log.info("Analyzer for language=" + analyzerKey + "is from a list of default language analyzers.");
+            log.info("Analyzer for language=" + analyzerKey + " is from a list of default language analyzers.");
             return setAndReturn(analyzerKey, defaultAnalyzers.get(language));
         }
         // set the default analyzer for the language

--- a/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/DefaultAnalyzers.java
+++ b/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/DefaultAnalyzers.java
@@ -1,0 +1,110 @@
+package lt.jocas.vespa.linguistics;
+
+import com.yahoo.language.Language;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.ar.ArabicAnalyzer;
+import org.apache.lucene.analysis.bg.BulgarianAnalyzer;
+import org.apache.lucene.analysis.bn.BengaliAnalyzer;
+import org.apache.lucene.analysis.ca.CatalanAnalyzer;
+import org.apache.lucene.analysis.ckb.SoraniAnalyzer;
+import org.apache.lucene.analysis.cz.CzechAnalyzer;
+import org.apache.lucene.analysis.da.DanishAnalyzer;
+import org.apache.lucene.analysis.de.GermanAnalyzer;
+import org.apache.lucene.analysis.el.GreekAnalyzer;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.es.SpanishAnalyzer;
+import org.apache.lucene.analysis.et.EstonianAnalyzer;
+import org.apache.lucene.analysis.eu.BasqueAnalyzer;
+import org.apache.lucene.analysis.fa.PersianAnalyzer;
+import org.apache.lucene.analysis.fi.FinnishAnalyzer;
+import org.apache.lucene.analysis.fr.FrenchAnalyzer;
+import org.apache.lucene.analysis.ga.IrishAnalyzer;
+import org.apache.lucene.analysis.gl.GalicianAnalyzer;
+import org.apache.lucene.analysis.hi.HindiAnalyzer;
+import org.apache.lucene.analysis.hu.HungarianAnalyzer;
+import org.apache.lucene.analysis.hy.ArmenianAnalyzer;
+import org.apache.lucene.analysis.id.IndonesianAnalyzer;
+import org.apache.lucene.analysis.it.ItalianAnalyzer;
+import org.apache.lucene.analysis.lt.LithuanianAnalyzer;
+import org.apache.lucene.analysis.lv.LatvianAnalyzer;
+import org.apache.lucene.analysis.ne.NepaliAnalyzer;
+import org.apache.lucene.analysis.nl.DutchAnalyzer;
+import org.apache.lucene.analysis.no.NorwegianAnalyzer;
+import org.apache.lucene.analysis.pt.PortugueseAnalyzer;
+import org.apache.lucene.analysis.ro.RomanianAnalyzer;
+import org.apache.lucene.analysis.ru.RussianAnalyzer;
+import org.apache.lucene.analysis.sr.SerbianAnalyzer;
+import org.apache.lucene.analysis.sv.SwedishAnalyzer;
+import org.apache.lucene.analysis.ta.TamilAnalyzer;
+import org.apache.lucene.analysis.te.TeluguAnalyzer;
+import org.apache.lucene.analysis.th.ThaiAnalyzer;
+import org.apache.lucene.analysis.tr.TurkishAnalyzer;
+
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+public class DefaultAnalyzers {
+
+    private static DefaultAnalyzers INSTANCE;
+    private final Map<Language, Analyzer> analyzerClasses;
+
+    private DefaultAnalyzers() {
+        analyzerClasses = Map.ofEntries(
+                entry(Language.ARABIC, new ArabicAnalyzer()),
+                entry(Language.BULGARIAN, new BulgarianAnalyzer()),
+                entry(Language.BENGALI, new BengaliAnalyzer()),
+                // analyzerClasses.put(Language.BRASILIAN, new BrazilianAnalyzer())
+                entry(Language.CATALAN, new CatalanAnalyzer()),
+                // cjk analyzer?
+                entry(Language.KURDISH, new SoraniAnalyzer()),
+                entry(Language.CZECH, new CzechAnalyzer()),
+                entry(Language.DANISH, new DanishAnalyzer()),
+                entry(Language.GERMAN, new GermanAnalyzer()),
+                entry(Language.GREEK, new GreekAnalyzer()),
+                entry(Language.ENGLISH, new EnglishAnalyzer()),
+                entry(Language.SPANISH, new SpanishAnalyzer()),
+                entry(Language.ESTONIAN, new EstonianAnalyzer()),
+                entry(Language.BASQUE, new BasqueAnalyzer()),
+                entry(Language.PERSIAN, new PersianAnalyzer()),
+                entry(Language.FINNISH, new FinnishAnalyzer()),
+                entry(Language.FRENCH, new FrenchAnalyzer()),
+                entry(Language.IRISH, new IrishAnalyzer()),
+                entry(Language.GALICIAN, new GalicianAnalyzer()),
+                entry(Language.HINDI, new HindiAnalyzer()),
+                entry(Language.HUNGARIAN, new HungarianAnalyzer()),
+                entry(Language.ARMENIAN, new ArmenianAnalyzer()),
+                entry(Language.INDONESIAN, new IndonesianAnalyzer()),
+                entry(Language.ITALIAN, new ItalianAnalyzer()),
+                entry(Language.LITHUANIAN, new LithuanianAnalyzer()),
+                entry(Language.LATVIAN, new LatvianAnalyzer()),
+                entry(Language.NEPALI, new NepaliAnalyzer()),
+                entry(Language.DUTCH, new DutchAnalyzer()),
+                entry(Language.NORWEGIAN_BOKMAL, new NorwegianAnalyzer()),
+                entry(Language.PORTUGUESE, new PortugueseAnalyzer()),
+                entry(Language.ROMANIAN, new RomanianAnalyzer()),
+                entry(Language.RUSSIAN, new RussianAnalyzer()),
+                entry(Language.SERBIAN, new SerbianAnalyzer()),
+                entry(Language.SWEDISH, new SwedishAnalyzer()),
+                entry(Language.TAMIL, new TamilAnalyzer()),
+                entry(Language.TELUGU, new TeluguAnalyzer()),
+                entry(Language.THAI, new ThaiAnalyzer()),
+                entry(Language.TURKISH, new TurkishAnalyzer())
+        );
+    }
+
+    public static DefaultAnalyzers getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new DefaultAnalyzers();
+        }
+        return INSTANCE;
+    }
+
+    public Analyzer get(Language language) {
+        return analyzerClasses.get(language);
+    }
+
+    public Analyzer get(String languageCode) {
+        return analyzerClasses.get(Language.fromLanguageTag(languageCode));
+    }
+}

--- a/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/LuceneLinguistics.java
+++ b/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/LuceneLinguistics.java
@@ -1,9 +1,11 @@
 package lt.jocas.vespa.linguistics;
 
 import com.google.inject.Inject;
+import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.language.Linguistics;
 import com.yahoo.language.process.*;
 import com.yahoo.language.simple.SimpleLinguistics;
+import org.apache.lucene.analysis.Analyzer;
 
 import java.util.ArrayList;
 import java.util.logging.Logger;
@@ -28,10 +30,10 @@ public class LuceneLinguistics extends SimpleLinguistics {
     private final LuceneAnalysisConfig config;
 
     @Inject
-    public LuceneLinguistics(LuceneAnalysisConfig config) {
+    public LuceneLinguistics(LuceneAnalysisConfig config, ComponentRegistry<Analyzer> analyzers) {
         log.info("Creating LuceneLinguistics with: " + config);
         this.config = config;
-        this.tokenizer = new LuceneTokenizer(config);
+        this.tokenizer = new LuceneTokenizer(config, analyzers);
         // NOOP stemmer
         this.stemmer = (word, stemMode, language) -> {
             ArrayList<StemList> stemLists = new ArrayList<>();

--- a/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/LuceneTokenizer.java
+++ b/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/LuceneTokenizer.java
@@ -49,10 +49,11 @@ public class LuceneTokenizer implements Tokenizer {
         try {
             tokenStream.reset();
             while (tokenStream.incrementToken()) {
-                // TODO: is SimpleToken good enough? Maybe a custom implmentation.
+                // TODO: is SimpleToken good enough? Maybe a custom implementation.
                 // TODO: what to do with cases when multiple tokens are inserted into the position?
+                String originalString = text.substring(offsetAttribute.startOffset(), offsetAttribute.endOffset());
                 String tokenString = charTermAttribute.toString();
-                tokens.add(new SimpleToken(tokenString, tokenString)
+                tokens.add(new SimpleToken(originalString, tokenString)
                         .setType(TokenType.ALPHABETIC)
                         .setOffset(offsetAttribute.startOffset())
                         .setScript(TokenScript.UNKNOWN));

--- a/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/LuceneTokenizer.java
+++ b/src/journal/vespa/linguistics/lucene/src/main/java/lt/jocas/vespa/linguistics/LuceneTokenizer.java
@@ -1,5 +1,6 @@
 package lt.jocas.vespa.linguistics;
 
+import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.language.Language;
 import com.yahoo.language.process.*;
 import com.yahoo.language.simple.SimpleToken;
@@ -24,7 +25,10 @@ public class LuceneTokenizer implements Tokenizer {
     private final AnalyzerFactory analyzerFactory;
 
     public LuceneTokenizer(LuceneAnalysisConfig config) {
-        this.analyzerFactory = new AnalyzerFactory(config);
+        this(config, new ComponentRegistry<>());
+    }
+    public LuceneTokenizer(LuceneAnalysisConfig config, ComponentRegistry<Analyzer> analyzers) {
+        this.analyzerFactory = new AnalyzerFactory(config, analyzers);
     }
 
     @Override

--- a/src/journal/vespa/linguistics/lucene/src/test/java/lt/jocas/vespa/linguistics/LuceneTokenizerTest.java
+++ b/src/journal/vespa/linguistics/lucene/src/test/java/lt/jocas/vespa/linguistics/LuceneTokenizerTest.java
@@ -1,5 +1,6 @@
 package lt.jocas.vespa.linguistics;
 
+import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.config.FileReference;
 import com.yahoo.language.Language;
 import com.yahoo.language.process.StemMode;
@@ -25,11 +26,19 @@ public class LuceneTokenizerTest {
                 .build());
         Iterable<Token> tokens = tokenizer
                 .tokenize(text, Language.ENGLISH, StemMode.ALL, true);
-        Iterator<Token> tokenIterator = tokens.iterator();
-        assertToken("this", tokenIterator);
-        assertToken("is", tokenIterator);
-        assertToken("my", tokenIterator);
-        assertToken("text", tokenIterator);
+        assertEquals(List.of("my", "text"), tokenStrings(tokens));
+    }
+
+    @Test
+    public void testLithuanianTokenizer() {
+        String text = "Žalgirio mūšio data yra 1410 metai";
+        var tokenizer = new LuceneTokenizer(new LuceneAnalysisConfig
+                .Builder()
+                .configDir(FileReference.mockFileReferenceForUnitTesting(new File(".")))
+                .build());
+        Iterable<Token> tokens = tokenizer
+                .tokenize(text, Language.LITHUANIAN, StemMode.ALL, true);
+        assertEquals(List.of("žalgir", "mūš", "dat", "1410", "met"), tokenStrings(tokens));
     }
 
     private void assertToken(String tokenString, Iterator<Token> tokens) {
@@ -73,7 +82,7 @@ public class LuceneTokenizerTest {
                                                         .Builder()
                                                         .name("uppercase"))))
                 ).build();
-        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig);
+        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig, new ComponentRegistry<>());
         Iterable<Token> tokens = linguistics
                 .getTokenizer()
                 .tokenize("Dogs and cats", Language.ENGLISH, StemMode.ALL, false);
@@ -94,7 +103,7 @@ public class LuceneTokenizerTest {
                                                 .Builder()
                                                 .name("englishMinimalStem"))))
                 ).build();
-        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig);
+        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig, new ComponentRegistry<>());
         Iterable<Token> tokens = linguistics
                 .getTokenizer()
                 .tokenize("Dogs and Cats", Language.ENGLISH, StemMode.ALL, false);
@@ -121,7 +130,7 @@ public class LuceneTokenizerTest {
                                                 .name("stop")
                                                 .conf("words", "stopwords.txt"))))
                 ).build();
-        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig);
+        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig, new ComponentRegistry<>());
         Iterable<Token> tokens = linguistics
                 .getTokenizer()
                 .tokenize("Dogs and Cats", Language.ENGLISH, StemMode.ALL, false);

--- a/src/journal/vespa/linguistics/vap/src/main/application/ext/document.json
+++ b/src/journal/vespa/linguistics/vap/src/main/application/ext/document.json
@@ -1,7 +1,7 @@
 {
   "put": "id:mynamespace:lucene::mydocid",
   "fields": {
-    "language": "lt",
+    "language": "en",
     "mytext": "sOMETHINGs Zero One Two Three Four Five Six Seven Eight"
   }
 }

--- a/src/journal/vespa/linguistics/vap/src/main/application/schemas/lucene.sd
+++ b/src/journal/vespa/linguistics/vap/src/main/application/schemas/lucene.sd
@@ -1,26 +1,14 @@
 schema lucene {
     document lucene {
         field language type string {
-            indexing: "en" | set_language
+            indexing: set_language
         }
         field mytext type string {
-            indexing: summary
-        }
-    }
-
-    field mytext_index type string {
-        indexing {
-            input mytext | lowercase | index;
+            indexing: summary | index
         }
     }
 
     fieldset default {
-        fields: mytext_index
-    }
-
-    rank-profile myrankprofile inherits default {
-        first-phase {
-            expression: nativeRank(mytext_index)
-        }
+        fields: mytext
     }
 }

--- a/src/journal/vespa/linguistics/vap/src/main/application/services.xml
+++ b/src/journal/vespa/linguistics/vap/src/main/application/services.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <services version="1.0">
   <container id="container" version="1.0">
+    <component id="en"
+               class="org.apache.lucene.analysis.core.SimpleAnalyzer"
+               bundle="vespa-lucene-linguistics-poc" />
+    <component id="pl"
+               class="lt.jocas.vespa.linguistics.analyzers.PolishAnalyzer"
+               bundle="vespa-lucene-linguistics-poc" />
     <component id="lt.jocas.vespa.linguistics.LuceneLinguistics" bundle="vespa-lucene-linguistics-poc">
       <config name="lt.jocas.vespa.linguistics.lucene-analysis">
         <configDir>lucene</configDir>

--- a/src/journal/vespa/linguistics/vap/src/main/java/lt/jocas/vespa/linguistics/analyzers/LithuanianAnalyzer.java
+++ b/src/journal/vespa/linguistics/vap/src/main/java/lt/jocas/vespa/linguistics/analyzers/LithuanianAnalyzer.java
@@ -1,0 +1,14 @@
+package lt.jocas.vespa.linguistics.analyzers;
+
+import com.yahoo.container.di.componentgraph.Provider;
+import org.apache.lucene.analysis.Analyzer;
+
+public class StandardAnalyzer implements Provider<Analyzer> {
+    @Override
+    public Analyzer get() {
+        return new org.apache.lucene.analysis.standard.StandardAnalyzer();
+    }
+
+    @Override
+    public void deconstruct() {}
+}

--- a/src/journal/vespa/linguistics/vap/src/main/java/lt/jocas/vespa/linguistics/analyzers/PolishAnalyzer.java
+++ b/src/journal/vespa/linguistics/vap/src/main/java/lt/jocas/vespa/linguistics/analyzers/PolishAnalyzer.java
@@ -3,10 +3,10 @@ package lt.jocas.vespa.linguistics.analyzers;
 import com.yahoo.container.di.componentgraph.Provider;
 import org.apache.lucene.analysis.Analyzer;
 
-public class LithuanianAnalyzer implements Provider<Analyzer> {
+public class PolishAnalyzer implements Provider<Analyzer> {
     @Override
     public Analyzer get() {
-        return new org.apache.lucene.analysis.lt.LithuanianAnalyzer();
+        return new org.apache.lucene.analysis.pl.PolishAnalyzer();
     }
 
     @Override

--- a/src/journal/vespa/linguistics/vap/src/main/java/lt/jocas/vespa/linguistics/analyzers/PolishAnalyzer.java
+++ b/src/journal/vespa/linguistics/vap/src/main/java/lt/jocas/vespa/linguistics/analyzers/PolishAnalyzer.java
@@ -3,10 +3,10 @@ package lt.jocas.vespa.linguistics.analyzers;
 import com.yahoo.container.di.componentgraph.Provider;
 import org.apache.lucene.analysis.Analyzer;
 
-public class StandardAnalyzer implements Provider<Analyzer> {
+public class LithuanianAnalyzer implements Provider<Analyzer> {
     @Override
     public Analyzer get() {
-        return new org.apache.lucene.analysis.standard.StandardAnalyzer();
+        return new org.apache.lucene.analysis.lt.LithuanianAnalyzer();
     }
 
     @Override

--- a/src/journal/vespa/linguistics/vap/src/test/java/lt/jocas/vespa/linguistics/lemmagen/LemmagenTokenFilterFactoryTest.java
+++ b/src/journal/vespa/linguistics/vap/src/test/java/lt/jocas/vespa/linguistics/lemmagen/LemmagenTokenFilterFactoryTest.java
@@ -1,5 +1,6 @@
 package lt.jocas.vespa.linguistics.lemmagen;
 
+import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.config.FileReference;
 import com.yahoo.language.Language;
 import com.yahoo.language.process.StemMode;
@@ -33,7 +34,7 @@ public class LemmagenTokenFilterFactoryTest {
                                                 .name("lemmagen")
                                                 .conf("lexicon", "sk.lem"))))
                 ).build();
-        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig);
+        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig, new ComponentRegistry<>());
         Iterable<Token> tokens = linguistics
                 .getTokenizer()
                 .tokenize("Mačky a psy", language, StemMode.ALL, false);

--- a/src/journal/vespa/linguistics/vap/src/test/java/lt/jocas/vespa/linguistics/stempel/StempelTokenFilterTest.java
+++ b/src/journal/vespa/linguistics/vap/src/test/java/lt/jocas/vespa/linguistics/stempel/StempelTokenFilterTest.java
@@ -1,5 +1,6 @@
 package lt.jocas.vespa.linguistics.stempel;
 
+import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.config.FileReference;
 import com.yahoo.language.Language;
 import com.yahoo.language.process.StemMode;
@@ -32,7 +33,7 @@ public class StempelTokenFilterTest {
                                                 .Builder()
                                                 .name("stempelPolishStem"))))
                 ).build();
-        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig);
+        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig, new ComponentRegistry<>());
         Iterable<Token> tokens = linguistics
                 .getTokenizer()
                 .tokenize("jeden i dwa", language, StemMode.ALL, false);


### PR DESCRIPTION
- Fixed Vespa Token construction: when the `orig` and `tokenString` are equal then characters from the original string are [used](https://github.com/vespa-engine/vespa/blob/50d7555bfe7bdaec86f8b31c4d316c9ba66bb976/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/linguistics/LinguisticsAnnotator.java#L95)!!! This caused the hard to explain behaviour in constructing the posting list. The error became obvious when I've used a Polish lemmatizer and looked at the posting list. The surprise was that a posting list entry had a space character. Which pointed to the fact that Linguistics annotation took offset from the `tokenString` but took the characters from the original string. Luckily Lucene OffsetAttribute exposes endOffset, so it is easy to produce `orig` string by cutting it from the input string. Which solves the mystery of what gets written to the index.
- Lucene analyzers class as application components.
- Default analyzers per language.